### PR TITLE
Deprecate code-1 (Code smell)

### DIFF
--- a/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -211,7 +211,8 @@ public class ProjectServiceImpl
         // .getSingleResult();
 
         // @formatter:off
-        String query = 
+        @SuppressWarnings("deprecation")
+		String query = 
                 "SELECT new " + SourceDocumentStateStats.class.getName() + "(" +
                 "COUNT(*), " +
                 "SUM(CASE WHEN state = '" + NEW.getId() + "'  THEN 1 ELSE 0 END), " +


### PR DESCRIPTION
1) Why the issue is relevant?
Deprecation is the process of taking the older code and marking it as no longer being useful with the codebase. The deprecated code has to be removed in order to reduce the maintenance burden. the method "annotation_finished" appears to be struck off which represents the code deprecation.

2)How do you address this issue and why do you think your solution solves the problem?
We have used @SupressWarnings annotation to address this issue, which disables certain compiler warnings. We believe that this solution is better when compared to the removal of code completely as the deprecated method exists in the framework and causes regression errors if removed. 