### PR TITLE
Bug- Resources should be changed

### DIFF
--- a/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -211,7 +211,8 @@ public class ProjectServiceImpl
         // .getSingleResult();
 
         // @formatter:off
-        String query = 
+        @SuppressWarnings("deprecation")
+		String query = 
                 "SELECT new " + SourceDocumentStateStats.class.getName() + "(" +
                 "COUNT(*), " +
                 "SUM(CASE WHEN state = '" + NEW.getId() + "'  THEN 1 ELSE 0 END), " +

--- a/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -211,8 +211,7 @@ public class ProjectServiceImpl
         // .getSingleResult();
 
         // @formatter:off
-        @SuppressWarnings("deprecation")
-		String query = 
+        String query = 
                 "SELECT new " + SourceDocumentStateStats.class.getName() + "(" +
                 "COUNT(*), " +
                 "SUM(CASE WHEN state = '" + NEW.getId() + "'  THEN 1 ELSE 0 END), " +
@@ -525,9 +524,10 @@ public class ProjectServiceImpl
         String guidelinePath = repositoryProperties.getPath().getAbsolutePath() + "/"
                 + PROJECT_FOLDER + "/" + aProject.getId() + "/" + GUIDELINES_FOLDER + "/";
         FileUtils.forceMkdir(new File(guidelinePath));
-        copyLarge(aIS, new FileOutputStream(new File(guidelinePath + aFileName)));
-
-        try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
+        try (FileOutputStream output = new FileOutputStream(new File(guidelinePath + aFileName))) {
+			copyLarge(aIS, output);
+		}
+		try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
                 String.valueOf(aProject.getId()))) {
             log.info("Created guidelines file [{}] in project [{}]({})", aFileName,
                     aProject.getName(), aProject.getId());


### PR DESCRIPTION
1.)    Why the issue is relevant?
The “FileOutputStream” is not closed in the “try” statement in the code. Usually, every “try” statement must be closed for every resource else it leads to major blockers in the code.

2)How do you address this issue and why do you think your solution solves the problem?
We have changed the "try" to a try-with-resources statement and added a local variable from line 527 as follows:
try (FileOutputStream output = new FileOutputStream(new File(guidelinePath + aFileName))) {
copyLarge(aIS, output);
}

The try-with-resources statement is a try statement that declares one or more resources. The try-with-resources statement ensures that each resource is closed at the end of the statement execution. 