### PR TITLE
Code smell (instance 2)- Local variables should not be declared and then immediately returned or thrown

### DIFF
--- a/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -157,7 +157,8 @@ public class ProjectServiceImpl
             log.info("Created project [{}]({})", aProject.getName(), aProject.getId());
         }
 
-        String path = repositoryProperties.getPath().getAbsolutePath() + "/" + PROJECT_FOLDER + "/"
+        String string = "/";
+		String path = repositoryProperties.getPath().getAbsolutePath() + string + PROJECT_FOLDER + string
                 + aProject.getId();
         FileUtils.forceMkdir(new File(path));
 
@@ -360,29 +361,33 @@ public class ProjectServiceImpl
     @Override
     public File getProjectFolder(Project aProject)
     {
-        return new File(repositoryProperties.getPath().getAbsolutePath() + "/" + PROJECT_FOLDER
-                + "/" + aProject.getId());
+        String string = "/";
+		return new File(repositoryProperties.getPath().getAbsolutePath() + string + PROJECT_FOLDER
+                + string + aProject.getId());
     }
 
     @Override
     public File getProjectLogFile(Project aProject)
     {
-        return new File(repositoryProperties.getPath().getAbsolutePath() + "/" + PROJECT_FOLDER
-                + "/" + "project-" + aProject.getId() + ".log");
+        String string = "/";
+		return new File(repositoryProperties.getPath().getAbsolutePath() + string + PROJECT_FOLDER
+                + string + "project-" + aProject.getId() + ".log");
     }
 
     @Override
     public File getGuidelinesFolder(Project aProject)
     {
-        return new File(repositoryProperties.getPath().getAbsolutePath() + "/" + PROJECT_FOLDER
-                + "/" + aProject.getId() + "/" + GUIDELINES_FOLDER + "/");
+        String string = "/";
+		return new File(repositoryProperties.getPath().getAbsolutePath() + string + PROJECT_FOLDER
+                + string + aProject.getId() + string + GUIDELINES_FOLDER + string);
     }
 
     @Override
     public File getMetaInfFolder(Project aProject)
     {
-        return new File(repositoryProperties.getPath().getAbsolutePath() + "/" + PROJECT_FOLDER
-                + "/" + aProject.getId() + "/" + META_INF_FOLDER + "/");
+        String string = "/";
+		return new File(repositoryProperties.getPath().getAbsolutePath() + string + PROJECT_FOLDER
+                + string + aProject.getId() + string + META_INF_FOLDER + string);
     }
 
     @Deprecated
@@ -396,8 +401,9 @@ public class ProjectServiceImpl
     @Override
     public File getGuideline(Project aProject, String aFilename)
     {
-        return new File(repositoryProperties.getPath().getAbsolutePath() + "/" + PROJECT_FOLDER
-                + "/" + aProject.getId() + "/" + GUIDELINES_FOLDER + "/" + aFilename);
+        String string = "/";
+		return new File(repositoryProperties.getPath().getAbsolutePath() + string + PROJECT_FOLDER
+                + string + aProject.getId() + string + GUIDELINES_FOLDER + string + aFilename);
     }
 
     @Override
@@ -521,8 +527,9 @@ public class ProjectServiceImpl
     public void createGuideline(Project aProject, InputStream aIS, String aFileName)
         throws IOException
     {
-        String guidelinePath = repositoryProperties.getPath().getAbsolutePath() + "/"
-                + PROJECT_FOLDER + "/" + aProject.getId() + "/" + GUIDELINES_FOLDER + "/";
+        String string = "/";
+		String guidelinePath = repositoryProperties.getPath().getAbsolutePath() + string
+                + PROJECT_FOLDER + string + aProject.getId() + string + GUIDELINES_FOLDER + string;
         FileUtils.forceMkdir(new File(guidelinePath));
         try (FileOutputStream output = new FileOutputStream(new File(guidelinePath + aFileName))) {
 			copyLarge(aIS, output);
@@ -631,7 +638,8 @@ public class ProjectServiceImpl
         entityManager.remove(project);
 
         // remove the project directory from the file system
-        String path = repositoryProperties.getPath().getAbsolutePath() + "/" + PROJECT_FOLDER + "/"
+        String string = "/";
+		String path = repositoryProperties.getPath().getAbsolutePath() + string + PROJECT_FOLDER + string
                 + aProject.getId();
         try {
             FastIOUtils.delete(new File(path));
@@ -653,9 +661,10 @@ public class ProjectServiceImpl
     @Override
     public void removeGuideline(Project aProject, String aFileName) throws IOException
     {
-        FileUtils.forceDelete(
-                new File(repositoryProperties.getPath().getAbsolutePath() + "/" + PROJECT_FOLDER
-                        + "/" + aProject.getId() + "/" + GUIDELINES_FOLDER + "/" + aFileName));
+        String string = "/";
+		FileUtils.forceDelete(
+                new File(repositoryProperties.getPath().getAbsolutePath() + string + PROJECT_FOLDER
+                        + string + aProject.getId() + string + GUIDELINES_FOLDER + string + aFileName));
 
         try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
                 String.valueOf(aProject.getId()))) {
@@ -682,14 +691,16 @@ public class ProjectServiceImpl
     public void savePropertiesFile(Project aProject, InputStream aIs, String aFileName)
         throws IOException
     {
-        String path = repositoryProperties.getPath().getAbsolutePath() + "/" + PROJECT_FOLDER + "/"
-                + aProject.getId() + "/" + FilenameUtils.getFullPath(aFileName);
+        String string = "/";
+		String path = repositoryProperties.getPath().getAbsolutePath() + string + PROJECT_FOLDER + string
+                + aProject.getId() + string + FilenameUtils.getFullPath(aFileName);
         FileUtils.forceMkdir(new File(path));
 
         File newTcfFile = new File(path, FilenameUtils.getName(aFileName));
         OutputStream os = null;
         try {
-            os = new FileOutputStream(newTcfFile);
+            FileOutputStream fileOutputStream = new FileOutputStream(newTcfFile);
+			os = fileOutputStream;
             copyLarge(aIs, os);
         }
         finally {

--- a/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -1049,9 +1049,8 @@ public class ProjectServiceImpl
         String query = "SELECT DISTINCT p FROM Project p, ProjectPermission pp "
                 + "WHERE pp.project = p.id " + "AND pp.level = :annotator "
                 + "GROUP BY p.id HAVING count(*) > 1 " + "ORDER BY p.name ASC";
-        List<Project> projects = entityManager.createQuery(query, Project.class)
+        return entityManager.createQuery(query, Project.class)
                 .setParameter("annotator", PermissionLevel.ANNOTATOR).getResultList();
-        return projects;
     }
 
     @Override

--- a/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -211,7 +211,8 @@ public class ProjectServiceImpl
         // .getSingleResult();
 
         // @formatter:off
-        String query = 
+        @SuppressWarnings("deprecation")
+		String query = 
                 "SELECT new " + SourceDocumentStateStats.class.getName() + "(" +
                 "COUNT(*), " +
                 "SUM(CASE WHEN state = '" + NEW.getId() + "'  THEN 1 ELSE 0 END), " +

--- a/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -1061,10 +1061,9 @@ public class ProjectServiceImpl
                 + "WHERE pp.project = p.id "
                 + "AND pp.user = :username AND (pp.level = :curator OR pp.level = :manager)"
                 + "ORDER BY p.name ASC";
-        List<Project> projects = entityManager.createQuery(query, Project.class)
+        return entityManager.createQuery(query, Project.class)
                 .setParameter("username", aUser.getUsername())
                 .setParameter("curator", PermissionLevel.CURATOR)
                 .setParameter("manager", PermissionLevel.MANAGER).getResultList();
-        return projects;
     }
 }

--- a/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -211,8 +211,7 @@ public class ProjectServiceImpl
         // .getSingleResult();
 
         // @formatter:off
-        @SuppressWarnings("deprecation")
-		String query = 
+        String query = 
                 "SELECT new " + SourceDocumentStateStats.class.getName() + "(" +
                 "COUNT(*), " +
                 "SUM(CASE WHEN state = '" + NEW.getId() + "'  THEN 1 ELSE 0 END), " +
@@ -525,9 +524,10 @@ public class ProjectServiceImpl
         String guidelinePath = repositoryProperties.getPath().getAbsolutePath() + "/"
                 + PROJECT_FOLDER + "/" + aProject.getId() + "/" + GUIDELINES_FOLDER + "/";
         FileUtils.forceMkdir(new File(guidelinePath));
-        copyLarge(aIS, new FileOutputStream(new File(guidelinePath + aFileName)));
-
-        try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
+        try (FileOutputStream output = new FileOutputStream(new File(guidelinePath + aFileName))) {
+			copyLarge(aIS, output);
+		}
+		try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
                 String.valueOf(aProject.getId()))) {
             log.info("Created guidelines file [{}] in project [{}]({})", aFileName,
                     aProject.getName(), aProject.getId());


### PR DESCRIPTION
1) Why is the issue relevant?
The local variables (“project” and “users”) were declared and immediately returned. There is no reason to throw the variable after declaration immediately, moreover this is an internal implementation that is not exposed to the callers of the method. This causes the code to be more complex and less understanding.

2) How do you address this issue and why do you think your solution solves the problem?
To address these issues, we decided to return the methods, because with the method’s name it is enough for the caller to know what to return. For example lines 1052 – 1056,  this is the original code 

List<Project> projects = entityManager.createQuery(query, Project.class)

                .setParameter("annotator",PermissionLevel.ANNOTATOR).getResultList();

        return projects;

And the proposed solution is:

return entityManager.createQuery(query, Project.class)

                .setParameter("annotator", PermissionLevel.ANNOTATOR).getResultList();