### PR TITLE
Code Smell: Sections of code must not be commented out

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -104,15 +104,7 @@ var AnnotatorUI = (function($, window, undefined) {
         return m[1]; // always matches
       }
 
-// WEBANNO EXTENSION BEGIN
-// We do not use the brat forms
-/*
-      var hideForm = function() {
-        keymap = null;
-        rapidAnnotationDialogVisible = false;
-      };
-*/
-// WEBANNO EXTENSIONE END
+
 
       var clearSelection = function() {
         window.getSelection().removeAllRanges();


### PR DESCRIPTION
Code smell: Some sections of the code are commented out in the code.
Explanation:
It is always a good practice not to comment out the code. Though comments are not compiled, it increases the compile time. While compiling the code, it read the comments and then ignores them. To successfully ignore comments it must read all the existing comments, this increases the compile time. Generally, comments are written to increase the readability of the code. Complex code can be easily understandable with the help of comments. They are very useful in increasing the understandability of the code.
Proposed Solution:
Unnecessary comments must be removed to reduce the compile time. Unused code must be removed to further increase the understandability. The first line in the commented code specified that "we do not use this brat form anymore". As we are not using them, it is always a good practice to remove the unused code instead of commenting on it.

Change:
Remove the comments at line number 107