### PR TITLE
added static keyword to LOG varaible to match the regular expression '…

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -151,7 +151,7 @@ public class AeroRemoteApiController
 
     private static final String FORMAT_DEFAULT = "text";
 
-    private final Logger LOG = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG = LoggerFactory.getLogger(getClass());
 
     private @Autowired DocumentService documentService;
     private @Autowired CurationDocumentService curationService;


### PR DESCRIPTION
code smell: 
Rename this field "LOG" to match the regular expression '^[a-z][a-zA-Z0-9]*$'.
Explanation:
Sharing some naming conventions is a key point to make it possible for a team to efficiently collaborate. This regex describes something which starts with lowercase and the remainder is composed of uppercase, lowercase, and numbers.
Solution:
To solve the above code smell I have added the static keyword, that every name has to start with a low character is one of the possibilities but we can't change the entire source code. So, I have added the static keyword which allows Local variables, class fields, and instance fields even they are capitalized.