### PR TITLE
Deprecated code

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/footer/WarningsFooterPanel.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/footer/WarningsFooterPanel.java
@@ -55,7 +55,7 @@ public class WarningsFooterPanel
     public WarningsFooterPanel(String aId)
     {
         super(aId);
-
+        @SuppressWarnings("deprecation")
         Properties settings = SettingsUtil.getSettings();
 
         // set up warnings shown when using an embedded DB or some unsupported browser


### PR DESCRIPTION
What is the code smell/issue found?
Deprecated classes, interfaces should be avoided for using, inheriting, extending. Deprecation is basically an indication that a particular class has been superseded and will be eventually be removed. The deprecation period allows us to make a smooth transition away from the aging, soon-to-be-retired technology.

How is this code smell relevant?
Deprecated code is code that is very old in age and no longer being used, this can increase the complexity and will make maintainability of the code difficult.

How can we resolve this issue?
Using @suppresswarnings annotation disables the compiler warnings, in our case about the deprecated code.
