### PR TITLE
Equality operators shopuld not be used in loops for termination

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -613,7 +613,7 @@ var AnnotatorUI = (function($, window, undefined) {
               if (((endRec.y != lastEndRec.y)) || ((startRec.y != lastStartRec.y))) {
                 // First check if we have to remove the first highlights because we are moving towards the end on a different line
                 var ss = 0;
-                for (; ss != selRect.length; ss++) {
+                for (; ss < selRect.length; ss++) {
                   if (startRec.y <= parseFloat(selRect[ss].getAttributeNS(null, "y"))) {
                     break;
                   }


### PR DESCRIPTION
Code smell: Changing the not equal to operator(!=) to less than operator(<) in the for loop.

Explanation:
In the loop "for(var s=0; s != selRect.length; s++) " the breaking condition suggests that the loop is broken the value of s equals the value of selRect.length. This is an issue because the loop will run infinitely until in case the value of s is greater than selRect.length.
Hence, changing the operator to less than makes sure that the loop is broken if s is greater than selRect.length.

