### PR TITLE
testcommit_1

### DIFF
--- a/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/webanno-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -302,12 +302,7 @@ public class ProjectServiceImpl
                 .getResultList();
 
         // if at least one permission level exist
-        if (projectPermissions.size() > 0) {
-            return true;
-        }
-        else {
-            return false;
-        }
+        return (!projectPermissions.isEmpty())?true:false;
     }
 
     @Override


### PR DESCRIPTION
Why the issue is relevant?

The if-else statement tests the condition. The if/else statement extends the if statement by identifying an action if the if (true/false expression) is false. In if/else we have to first cache the initial state of the if and then uncached it in several lines later.

How do you address this issue and why do you think your solution solves the problem?
we have used a return statement because it is easily understandable and we don't need to worry about what will be coming after else statement. The return should be in the last line in a function that returns either a predefined value or the last variable in the function. Else is intended to restrictively execute code if the function is false.

