### PR TITLE
Code Smell- Insufficient Error Handling-   . (BR1-Issue5)

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -611,6 +611,10 @@ public class AeroRemoteApiController
 
                 return new ResponseEntity<>(resource, httpHeaders, OK);
             }
+            catch(Exception ex){
+            	throw new IllegalObjectStateException(
+                        "There is a problem of Loading the File into memory Error Code:[%s] ", ex.getMessage());
+            }
             finally {
                 if (exportedFile != null) {
                     FileUtils.forceDelete(exportedFile);


### PR DESCRIPTION
Why code smell issue is relevant?

As reference to Issue 5 BR1. I inspected the code issues regarding Exception Handling. I found 3 occurance of the same issue Where The catch Block was missing to handle the Exception. I have replaced all the occurrence with the updated type which was required.

How and Why I think Issue is resolved?
I have added The catchblock for 1st occurrence at line 614. Which will through Exception if File is failed to create for some Reason.  I think it will help user to understand why the file failed to be created by provided him the failure reason.

How and Why I think Issue is resolved?
I have replaced the required application type a as per documentation. As the previous type was depreciated in favour of this new type that I replaced. So all depreciation warnings are gone.

**What's in the PR**
* ...

**How to test manually**
* ...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
