### PR TITLE
Replaced '@RequestMapping(method = RequestMethod.GET)' with '@GetMapp…

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -257,8 +257,8 @@ public class AeroRemoteApiController
     }
 
     @ApiOperation(value = "List the projects accessible by the authenticated user")
-    @RequestMapping(value = ("/"
-            + PROJECTS), method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = ("/"
+            + PROJECTS),produces = APPLICATION_JSON_UTF8_VALUE)
     public ResponseEntity<RResponse<List<RProject>>> projectList() throws Exception
     {
         // Get current user - this will throw an exception if the current user does not exit


### PR DESCRIPTION
code smell:
Composed "@RequestMapping" variants should be preferred.
Explanation:
Variants of the @RequestMapping annotation to better represent the semantics of the annotated methods. The use of @GetMapping, @PostMapping, @PutMapping, @PatchMapping, and @DeleteMapping should be preferred to the use of the raw @RequestMapping(method = RequestMethod.XYZ).
Solution:
To solve the above code smell I replaced '@RequestMapping(method = RequestMethod.GET)' with '@GetMapping' for the representation of the semantics of the annotated methods.