### PR TITLE
Deprecated code 2

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -168,6 +168,7 @@ public class LoginPage
             add(new RequiredTextField<String>("username"));
             add(new PasswordTextField("password"));
             add(new HiddenField<>("urlfragment"));
+            @SuppressWarnings("deprecation")
             Properties settings = SettingsUtil.getSettings();
             String loginMessage = settings.getProperty(SettingsUtil.CFG_LOGIN_MESSAGE);
             add(new Label("loginMessage", loginMessage).setEscapeModelStrings(false)


### PR DESCRIPTION
What is the code smell/issue found?
Deprecated classes, interfaces should be avoided for using, inheriting, extending. Deprecation is basically an indication that a particular class has been superseded and will be eventually be removed. The deprecation period allows us to make a smooth transition away from the aging, soon-to-be-retired technology.

How is this code smell relevant?
Deprecated code is code that is very old in age and no longer being used, this can increase the complexity and will make maintainability of the code difficult.

How can we resolve this issue?
Using @SuppressWarnings annotation disables the compiler warnings, in our case about the deprecated code.
