### PR TITLE
Code Smell- Insufficient Error Handling- . (BR1-Issue5) 2nd occurrence 

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -898,6 +898,10 @@ public class AeroRemoteApiController
                     format, doc.getName(), Mode.ANNOTATION);
             resource = FileUtils.readFileToByteArray(exportedAnnoFile);
         }
+        catch(Exception ex){
+        	throw new IllegalObjectStateException(
+                    "There is a problem of Loading the File into memory Error Message:[%s] ", ex.getMessage());
+        }
         finally {
             if (exportedAnnoFile != null) {
                 FileUtils.forceDelete(exportedAnnoFile);


### PR DESCRIPTION
Why code smell issue is relevant?

As reference to Issue 5 BR1. I inspected the code issues regarding Exception Handling. I found 3 occurance of the same issue Where The catch Block was missing to handle the Exception. I have replaced all the occurrence with the updated type which was required.

How and Why I think Issue is resolved?
I have added The catchblock for 2nd occurrence at line 614. Which will through Exception if File is failed to create for some Reason. I think it will help user to understand why the file failed to be created by provided him the failure reason.
