### PR TITLE
Format specifiers are used instead of string concatenation.

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -307,7 +307,7 @@ public class AeroRemoteApiController
         }
 
         // Create the project and initialize tags
-        LOG.info("Creating project [" + aName + "]");
+        LOG.info(String.format("Creating project ['%s']",aName) );
         Project project = new Project();
         project.setName(aName);
         project.setMode(WebAnnoConst.PROJECT_TYPE_ANNOTATION);


### PR DESCRIPTION
code smell:
Printf-style format strings should be used correctly.
Explanation:
Because printf-style format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that result in the wrong strings being created. This rule statically validates the correlation of printf-style format strings to their arguments when calling the format(...) methods of java.util.Formatter, java.lang.String, java.io.PrintStream, MessageFormat, and java.io.PrintWriter classes and the printf(...) methods of java.io.PrintStream or java.io.PrintWriter classes.
Solution:
To solve the above code smell I updated the string concatenation with the desired format specifiers.