### PR TITLE
Switch statements having less than 3 case clauses

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
@@ -118,16 +118,13 @@ public abstract class ApplicationPageBase
 
         // Override locale to be used by application
         String locale = settings.getProperty(SettingsUtil.CFG_LOCALE, "en");
-        switch (locale) {
-        case "auto":
-            // Do nothing - locale is picked up from browser
-            break;
-        default:
-            // Override the locale in the session
-            getSession().setLocale(Locale.forLanguageTag(locale));
-            break;
+        if(locale == auto)
+        {// Do nothing - locale is picked up from browser
         }
-
+        else
+        {// Override the locale in the session
+        getSession().setLocale(Locale.forLanguageTag(locale));
+        }
         // Add menubar
         try {
             Class<? extends Component> menubarClass = getApplication().getMetaData(MENUBAR_CLASS);


### PR DESCRIPTION
What is the code smell/ issue?
Using switch statements at instances that can have less than 3 case clauses.
How is this code smell/ issue relevant?
Using switch statements that have less than 3 case clauses can be replaced and simplified by using if statement, This can cause readability issues.
How can this issue be fixed?
Replacing switch statements with if statements can improve the readability of the code and fix this issue.

