### PR TITLE
Replaced '@RequestMapping(method = RequestMethod.DELETE)' with '@Dele…

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -344,8 +344,8 @@ public class AeroRemoteApiController
     }
 
     @ApiOperation(value = "Delete an existing project")
-    @RequestMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID
-            + "}"), method = RequestMethod.DELETE, produces = APPLICATION_JSON_UTF8_VALUE)
+    @DeleteMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID
+            + "}"), produces = APPLICATION_JSON_UTF8_VALUE)
     public ResponseEntity<RResponse<Void>> projectDelete(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId)
         throws Exception


### PR DESCRIPTION
code smell:
Composed "@RequestMapping" variants should be preferred.
Explanation:
Variants of the @RequestMapping annotation to better represent the semantics of the annotated methods. The use of @GetMapping, @PostMapping, @PutMapping, @PatchMapping, and @DeleteMapping should be preferred to the use of the raw @RequestMapping(method = RequestMethod.XYZ).
Solution:
To solve the above code smell I replaced '@RequestMapping(method = RequestMethod.DELETE)' with '@DeleteMapping' for the representation of the semantics of the annotated methods.