### PR TITLE
Removed 'APPLICATION_JSON_UTF8_VALUE' as it is deprecated.

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -345,7 +345,7 @@ public class AeroRemoteApiController
 
     @ApiOperation(value = "Delete an existing project")
     @RequestMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID
-            + "}"), method = RequestMethod.DELETE, produces = APPLICATION_JSON_UTF8_VALUE)
+            + "}"), method = RequestMethod.DELETE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<Void>> projectDelete(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId)
         throws Exception


### PR DESCRIPTION
Code smell:
"@deprecated" code should not be used.
Explanation:
Once deprecated, classes, and interfaces, and their members should be avoided, rather than used, inherited, or extended. Deprecation is a warning that the class or interface has been superseded, and will eventually be removed. The deprecation period allows you to make a smooth transition away from the aging, soon-to-be-retired technology.
Solution:
To solve the above code smell I removed "APPLICATION_JSON_UTF8_VALUE" as it is deprecated and replaced it with "APPLICATION_JSON_VALUE".