### PR TITLE
"if" condition is added for nullable state.

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -505,18 +505,22 @@ public class AeroRemoteApiController
         // Set state if one was provided
         if (aState.isPresent()) {
             SourceDocumentState state = parseSourceDocumentState(aState.get());
-            switch (state) {
-            case NEW: // fallthrough
-            case ANNOTATION_IN_PROGRESS: // fallthrough
-            case ANNOTATION_FINISHED: // fallthrough
-                document.setState(state);
-                documentService.createSourceDocument(document);
-                break;
-            case CURATION_IN_PROGRESS: // fallthrough
-            case CURATION_FINISHED:
-            default:
-                throw new IllegalObjectStateException(
-                        "State [%s] not valid when uploading a document.", aState.get());
+            if(state!=null)
+            {
+                switch (state)
+                {
+                    case NEW: // fallthrough
+                    case ANNOTATION_IN_PROGRESS: // fallthrough
+                    case ANNOTATION_FINISHED: // fallthrough
+                        document.setState(state);
+                        documentService.createSourceDocument(document);
+                        break;
+                    case CURATION_IN_PROGRESS: // fallthrough
+                    case CURATION_FINISHED:
+                    default:
+                        throw new IllegalObjectStateException(
+                                "State [%s] not valid when uploading a document.", aState.get());
+                }
             }
         }
 


### PR DESCRIPTION
Bug:
the “state” variable used in the switch statement may be null
Explanation: 
referencing to a “null” value can never be accessed, doing so will cause a NullPointerException. It may cause the abrupt termination of the application.
Solution: 
Make sure the variable “state” is can never be null and suppress the warning. If not, handling the case where the variable is null separately using the If condition.
