### PR TITLE
Generic Exception Issue fixed

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -1076,8 +1076,7 @@ public class AeroRemoteApiController
             return "NEW";
         case ANNOTATION_IN_PROGRESS:
             return "ANNOTATION-IN-PROGRESS";
-            //noinspection deprecation
-            case ANNOTATION_FINISHED:
+        case ANNOTATION_FINISHED:
             return "ANNOTATION-COMPLETE";
         case CURATION_FINISHED:
             return "CURATION-COMPLETE";
@@ -1099,8 +1098,7 @@ public class AeroRemoteApiController
             return "NEW";
         case ANNOTATION_IN_PROGRESS:
             return "ANNOTATION-IN-PROGRESS";
-            //noinspection deprecation
-            case ANNOTATION_FINISHED:
+        case ANNOTATION_FINISHED:
             return "ANNOTATION-COMPLETE";
         case CURATION_FINISHED:
             return "CURATION-COMPLETE";

--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -508,7 +508,8 @@ public class AeroRemoteApiController
             switch (state) {
             case NEW: // fallthrough
             case ANNOTATION_IN_PROGRESS: // fallthrough
-            case ANNOTATION_FINISHED: // fallthrough
+                //noinspection deprecation
+                case ANNOTATION_FINISHED: // fallthrough
                 document.setState(state);
                 documentService.createSourceDocument(document);
                 break;
@@ -791,7 +792,8 @@ public class AeroRemoteApiController
                 break;
             case NEW: // fallthrough
             case ANNOTATION_IN_PROGRESS: // fallthrough
-            case ANNOTATION_FINISHED: // fallthrough
+                //noinspection deprecation
+                case ANNOTATION_FINISHED: // fallthrough
             default:
                 throw new IllegalObjectStateException(
                         "State [%s] not valid when uploading a curation.", aState.get());
@@ -1055,6 +1057,7 @@ public class AeroRemoteApiController
         case "ANNOTATION-IN-PROGRESS":
             return SourceDocumentState.ANNOTATION_IN_PROGRESS;
         case "ANNOTATION-COMPLETE":
+            //noinspection deprecation
             return SourceDocumentState.ANNOTATION_FINISHED;
         case "CURATION-COMPLETE":
             return SourceDocumentState.CURATION_FINISHED;
@@ -1070,13 +1073,13 @@ public class AeroRemoteApiController
         if (aState == null) {
             return null;
         }
-
         switch (aState) {
         case NEW:
             return "NEW";
         case ANNOTATION_IN_PROGRESS:
             return "ANNOTATION-IN-PROGRESS";
-        case ANNOTATION_FINISHED:
+            //noinspection deprecation
+            case ANNOTATION_FINISHED:
             return "ANNOTATION-COMPLETE";
         case CURATION_FINISHED:
             return "CURATION-COMPLETE";
@@ -1098,7 +1101,8 @@ public class AeroRemoteApiController
             return "NEW";
         case ANNOTATION_IN_PROGRESS:
             return "ANNOTATION-IN-PROGRESS";
-        case ANNOTATION_FINISHED:
+            //noinspection deprecation
+            case ANNOTATION_FINISHED:
             return "ANNOTATION-COMPLETE";
         case CURATION_FINISHED:
             return "CURATION-COMPLETE";

--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -23,8 +23,8 @@ import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMes
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMessageLevel.INFO;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.OK;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
@@ -166,7 +166,7 @@ public class AeroRemoteApiController
         throws IOException
     {
         LOG.error(aException.getMessage(), aException);
-        return ResponseEntity.status(aException.getStatus()).contentType(APPLICATION_JSON_UTF8)
+        return ResponseEntity.status(aException.getStatus()).contentType(APPLICATION_JSON)
                 .body(new RResponse<>(ERROR, aException.getMessage()));
     }
 
@@ -174,7 +174,7 @@ public class AeroRemoteApiController
     public ResponseEntity<RResponse<Void>> handleException(Exception aException) throws IOException
     {
         LOG.error(aException.getMessage(), aException);
-        return ResponseEntity.status(INTERNAL_SERVER_ERROR).contentType(APPLICATION_JSON_UTF8)
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).contentType(APPLICATION_JSON)
                 .body(new RResponse<>(ERROR, "Internal server error: " + aException.getMessage()));
     }
 
@@ -258,7 +258,7 @@ public class AeroRemoteApiController
 
     @ApiOperation(value = "List the projects accessible by the authenticated user")
     @RequestMapping(value = ("/"
-            + PROJECTS), method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
+            + PROJECTS), method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<List<RProject>>> projectList() throws Exception
     {
         // Get current user - this will throw an exception if the current user does not exit
@@ -282,7 +282,7 @@ public class AeroRemoteApiController
             value = ("/" + PROJECTS), //
             method = RequestMethod.POST, //
             consumes = MULTIPART_FORM_DATA_VALUE, //
-            produces = APPLICATION_JSON_UTF8_VALUE)
+            produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<RProject>> projectCreate(@RequestParam(PARAM_NAME) String aName,
             @RequestParam(PARAM_CREATOR) Optional<String> aCreator, UriComponentsBuilder aUcb)
         throws Exception
@@ -332,7 +332,7 @@ public class AeroRemoteApiController
 
     @ApiOperation(value = "Get information about a project")
     @RequestMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID
-            + "}"), method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
+            + "}"), method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<RProject>> projectRead(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId)
         throws Exception
@@ -345,7 +345,7 @@ public class AeroRemoteApiController
 
     @ApiOperation(value = "Delete an existing project")
     @RequestMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID
-            + "}"), method = RequestMethod.DELETE, produces = APPLICATION_JSON_UTF8_VALUE)
+            + "}"), method = RequestMethod.DELETE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<Void>> projectDelete(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId)
         throws Exception
@@ -363,7 +363,7 @@ public class AeroRemoteApiController
             value = ("/" + PROJECTS + "/" + IMPORT), //
             method = RequestMethod.POST, //
             consumes = MULTIPART_FORM_DATA_VALUE, //
-            produces = APPLICATION_JSON_UTF8_VALUE)
+            produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<RProject>> projectImport(
             @RequestPart(PARAM_FILE) MultipartFile aFile)
         throws Exception
@@ -403,7 +403,7 @@ public class AeroRemoteApiController
     @ApiOperation(value = "Export a project to a ZIP file")
     @RequestMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/"
             + EXPORT), method = RequestMethod.GET, produces = { "application/zip",
-                    APPLICATION_JSON_UTF8_VALUE })
+                    APPLICATION_JSON_VALUE })
     public ResponseEntity<InputStreamResource> projectExport(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @RequestParam(value = PARAM_FORMAT) Optional<String> aFormat)
@@ -451,7 +451,7 @@ public class AeroRemoteApiController
 
     @ApiOperation(value = "List documents in a project")
     @RequestMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/"
-            + DOCUMENTS, method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
+            + DOCUMENTS, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<List<RDocument>>> documentList(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId)
         throws Exception
@@ -477,7 +477,7 @@ public class AeroRemoteApiController
             value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS, //
             method = RequestMethod.POST, //
             consumes = MULTIPART_FORM_DATA_VALUE, //
-            produces = APPLICATION_JSON_UTF8_VALUE)
+            produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<RDocument>> documentCreate(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @RequestParam(PARAM_CONTENT) MultipartFile aFile,
@@ -541,7 +541,7 @@ public class AeroRemoteApiController
     @ApiOperation(value = "Get a document from a project", response = byte[].class)
     @RequestMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID + "}", method = RequestMethod.GET, produces = {
-                    APPLICATION_OCTET_STREAM_VALUE, APPLICATION_JSON_UTF8_VALUE })
+                    APPLICATION_OCTET_STREAM_VALUE, APPLICATION_JSON_VALUE })
     public ResponseEntity documentRead(@PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @PathVariable(PARAM_DOCUMENT_ID) long aDocumentId,
             @RequestParam(value = PARAM_FORMAT) Optional<String> aFormat)
@@ -622,7 +622,7 @@ public class AeroRemoteApiController
     @ApiOperation(value = "Delete a document from a project")
     @RequestMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID
-            + "}", method = RequestMethod.DELETE, produces = APPLICATION_JSON_UTF8_VALUE)
+            + "}", method = RequestMethod.DELETE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<Void>> documentDelete(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @PathVariable(PARAM_DOCUMENT_ID) long aDocumentId)
@@ -641,7 +641,7 @@ public class AeroRemoteApiController
     @ApiOperation(value = "List annotations of a document in a project")
     @RequestMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID + "}/"
-            + ANNOTATIONS, method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
+            + ANNOTATIONS, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<List<RAnnotation>>> annotationsList(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @PathVariable(PARAM_DOCUMENT_ID) long aDocumentId)
@@ -671,7 +671,7 @@ public class AeroRemoteApiController
                     + PARAM_DOCUMENT_ID + "}/" + ANNOTATIONS + "/{" + PARAM_ANNOTATOR_ID + "}", //
             method = RequestMethod.POST, //
             consumes = MULTIPART_FORM_DATA_VALUE, //
-            produces = APPLICATION_JSON_UTF8_VALUE)
+            produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<RAnnotation>> annotationsCreate(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @PathVariable(PARAM_DOCUMENT_ID) long aDocumentId,
@@ -715,7 +715,7 @@ public class AeroRemoteApiController
     @RequestMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID + "}/" + ANNOTATIONS + "/{" + PARAM_ANNOTATOR_ID
             + "}", method = RequestMethod.GET, produces = { APPLICATION_OCTET_STREAM_VALUE,
-                    APPLICATION_JSON_UTF8_VALUE })
+                    APPLICATION_JSON_VALUE })
     public ResponseEntity<byte[]> annotationsRead(@PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @PathVariable(PARAM_DOCUMENT_ID) long aDocumentId,
             @PathVariable(PARAM_ANNOTATOR_ID) String aAnnotatorId,
@@ -729,7 +729,7 @@ public class AeroRemoteApiController
     @ApiOperation(value = "Delete a user's annotations of one document from a project")
     @RequestMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID + "}/" + ANNOTATIONS + "/{" + PARAM_ANNOTATOR_ID
-            + "}", method = RequestMethod.DELETE, produces = APPLICATION_JSON_UTF8_VALUE)
+            + "}", method = RequestMethod.DELETE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<Void>> annotationsDelete(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @PathVariable(PARAM_DOCUMENT_ID) long aDocumentId,
@@ -758,7 +758,7 @@ public class AeroRemoteApiController
                     "/{" + PARAM_DOCUMENT_ID + "}/" + CURATION, //
             method = RequestMethod.POST, //
             consumes = MULTIPART_FORM_DATA_VALUE, //
-            produces = APPLICATION_JSON_UTF8_VALUE)
+            produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<RAnnotation>> curationCreate(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @PathVariable(PARAM_DOCUMENT_ID) long aDocumentId,
@@ -813,7 +813,7 @@ public class AeroRemoteApiController
     @ApiOperation(value = "Get curated annotations of a document in a project", response = byte[].class)
     @RequestMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID + "}/" + CURATION, method = RequestMethod.GET, produces = {
-                    APPLICATION_OCTET_STREAM_VALUE, APPLICATION_JSON_UTF8_VALUE })
+                    APPLICATION_OCTET_STREAM_VALUE, APPLICATION_JSON_VALUE })
     public ResponseEntity<byte[]> curationRead(@PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @PathVariable(PARAM_DOCUMENT_ID) long aDocumentId,
             @RequestParam(value = PARAM_FORMAT) Optional<String> aFormat)
@@ -826,7 +826,7 @@ public class AeroRemoteApiController
     @ApiOperation(value = "Delete a user's annotations of one document from a project")
     @RequestMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID + "}/"
-            + CURATION, method = RequestMethod.DELETE, produces = APPLICATION_JSON_UTF8_VALUE)
+            + CURATION, method = RequestMethod.DELETE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<Void>> curationDelete(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,
             @PathVariable(PARAM_DOCUMENT_ID) long aDocumentId)

--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -1076,7 +1076,8 @@ public class AeroRemoteApiController
             return "NEW";
         case ANNOTATION_IN_PROGRESS:
             return "ANNOTATION-IN-PROGRESS";
-        case ANNOTATION_FINISHED:
+            //noinspection deprecation
+            case ANNOTATION_FINISHED:
             return "ANNOTATION-COMPLETE";
         case CURATION_FINISHED:
             return "CURATION-COMPLETE";
@@ -1098,7 +1099,8 @@ public class AeroRemoteApiController
             return "NEW";
         case ANNOTATION_IN_PROGRESS:
             return "ANNOTATION-IN-PROGRESS";
-        case ANNOTATION_FINISHED:
+            //noinspection deprecation
+            case ANNOTATION_FINISHED:
             return "ANNOTATION-COMPLETE";
         case CURATION_FINISHED:
             return "CURATION-COMPLETE";


### PR DESCRIPTION
Why code smell issue is relevant?
As reference to BR1-Issue 10 I investigated the issue. I found more than 10 occrance of this issue where generic exception handling was done. I found the reason why last developer did it as methods where throwing more than one kind of exception.

How and Why I think Issue is resolved?
I have replaced all generic Exception classes to specific subclasses for each method which is throwing an exception.