### PR TITLE
A 'NullPointerException' is fixed, state nullable.

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -778,23 +778,25 @@ public class AeroRemoteApiController
         AnnotationDocumentState resultState = AnnotationDocumentState.IN_PROGRESS;
         if (aState.isPresent()) {
             SourceDocumentState state = parseSourceDocumentState(aState.get());
-            switch (state) {
-            case CURATION_IN_PROGRESS:
-                resultState = AnnotationDocumentState.IN_PROGRESS;
-                document.setState(state);
-                documentService.createSourceDocument(document);
-                break;
-            case CURATION_FINISHED:
-                resultState = AnnotationDocumentState.FINISHED;
-                document.setState(state);
-                documentService.createSourceDocument(document);
-                break;
-            case NEW: // fallthrough
-            case ANNOTATION_IN_PROGRESS: // fallthrough
-            case ANNOTATION_FINISHED: // fallthrough
-            default:
-                throw new IllegalObjectStateException(
-                        "State [%s] not valid when uploading a curation.", aState.get());
+            if(state!=null) {
+                switch (state) {
+                    case CURATION_IN_PROGRESS:
+                        resultState = AnnotationDocumentState.IN_PROGRESS;
+                        document.setState(state);
+                        documentService.createSourceDocument(document);
+                        break;
+                    case CURATION_FINISHED:
+                        resultState = AnnotationDocumentState.FINISHED;
+                        document.setState(state);
+                        documentService.createSourceDocument(document);
+                        break;
+                    case NEW: // fallthrough
+                    case ANNOTATION_IN_PROGRESS: // fallthrough
+                    case ANNOTATION_FINISHED: // fallthrough
+                    default:
+                        throw new IllegalObjectStateException(
+                                "State [%s] not valid when uploading a curation.", aState.get());
+                }
             }
         }
         else {


### PR DESCRIPTION
Bug:
the “state” variable used in the switch statement may be null
Explanation:
referencing to a “null” value can never be accessed, doing so will cause a NullPointerException. It may cause the abrupt termination of the application.
Solution:
Make sure the variable “state” is can never be null and suppress the warning. If not, handling the case where the variable is null separately using the If condition.