### PR TITLE
variables should be declared explicitly

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -374,7 +374,7 @@ var AnnotatorUI = (function($, window, undefined) {
         }
         
         svgElement.addClass('unselectable');
-        svgPosition = svgElement.offset();
+        let svgPosition = svgElement.offset();
         arcDragOrigin = originId;
         arcDragArc = svg.path(svg.createPath(), {
           markerEnd: 'url(#drag_arrow)',
@@ -566,9 +566,9 @@ var AnnotatorUI = (function($, window, undefined) {
             chunkIndexTo = endsAt && $(endsAt).attr('data-chunk-id');
 
             // Now take the start and end character rectangles
-            startRec = startsAt.getExtentOfChar(anchorOffset);
+            let startRec = startsAt.getExtentOfChar(anchorOffset);
             startRec.y += 2;
-            endRec = endsAt.getExtentOfChar(focusOffset);
+            let endRec = endsAt.getExtentOfChar(focusOffset);
             endRec.y += 2;
 
             // If nothing has changed then stop here
@@ -1767,7 +1767,7 @@ var AnnotatorUI = (function($, window, undefined) {
         	catch (err) {
         	  // Ignore - could be spurious TypeError: null is not an object (evaluating 'a.parentNode.removeChild')
         	}
-            arcDrag = null;
+            let arcDrag = null;
           }
           arcDragOrigin = null;
           if (arcOptions) {
@@ -2440,7 +2440,7 @@ var AnnotatorUI = (function($, window, undefined) {
         // clear possible existing
         $norm_select.empty();
         // fill in new
-        html = [];
+        let html = [];
         $.each(norm_resources, function(normNo, norm) {
           var normName = norm[0], normUrl = norm[1], normUrlBase = norm[2];
           var serverDb = norm[3];
@@ -2490,7 +2490,7 @@ var AnnotatorUI = (function($, window, undefined) {
             dispatcher.post('messages', [[['Base URL "'+base+'" for '+normDb+' does not contain "%s"', 'error']]]);
           } else {
             // TODO: protect against strange chars in ID
-            link = base.replace('%s', normId);
+            let link = base.replace('%s', normId);
             $normLink.attr('href', link);
             $normLink.show();
           }


### PR DESCRIPTION
Code smell: Variables should be declared explicitly.
Explanation:
Both the keywords "let" and "var" are used to declare variables in javascript. let is used to declare a variable for a single scope. Normally the keyword "var" is used to declare a variable in JavaScript, but the keyword "let" is used to declare a variable in a block of code, where the scope of the variable is restricted to that particular block.
Proposed Solution:
Few of the variables are not declared before using them. Few of them are defined but the scope of the variable is changed hence making it undeclared. There are 6 code smells of the same type "variables should be declared explicitly" 
