### PR TITLE
equality operator should not be used in terminating loop

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -620,7 +620,7 @@ var AnnotatorUI = (function($, window, undefined) {
                 }
                 // Next check for any end highlights if we are moving towards the start on a different line
                 var es = selRect.length - 1;
-                for (; es != -1; es--) {
+                for (; es > -1; es--) {
                   if (endRec.y >= parseFloat(selRect[es].getAttributeNS(null, "y"))) {
                     break;
                   }


### PR DESCRIPTION
Code smell: changing the not equals to operator(!=) to less than operator().
Explanation: 

In the for loop "for (; es != -1; es--)" there is a chance that the loop might run infinitely if the value of es variable is less than -1. Hence changing the loop to "for (; es > -1; es--)" fixes this issue