### PR TITLE
deprecated code

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -281,9 +281,8 @@ var AnnotatorUI = (function($, window, undefined) {
 // WEBANNO EXTENSION END - #520 Perform javascript action on click 
 
 // WEBANNO EXTENSION BEGIN - #863 Allow configuration of default value for "auto-scroll" etc.
-/*
-      var onDblClick = function(evt) {
-*/
+// Here was the declaration of onDblClick, maybe onDblClick was changed to editAnnotation
+
       var editAnnotation = function(evt) {
 // WEBANNO EXTENSION END - #863 Allow configuration of default value for "auto-scroll" etc.
         // must be logged in


### PR DESCRIPTION
Code smell: Deprecated Code 
Explanation: The following code "var onDblClick = function(evt) {" was commented. The function was opened but never closed, making it incomplete code. So the following set of codes can be deleted. One possible interpretation was that initially the function "onDblClick" was created but later it was changed to "editAnnotation".
Proposed Solution:
One possible solution was remove the commented code and instead add a comment "onDblClick was changed to editAnnotation" so that even in the future if anyone searched for "onDblCick", they can find that it was changed into another function. In doing so commented code can be deleted and even if it was changed to another function, there will be no issues.