### PR TITLE
Assignments should not be made from within sub-expressions

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/MenuBar.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/MenuBar.java
@@ -48,7 +48,8 @@ public class MenuBar
 
         add(new LogoutPanel("logoutPanel"));
 
-        add(helpLink = new ExternalLink("helpLink", new ResourceModel("page.help.link", ""))
+        helpLink = new ExternalLink("helpLink", new ResourceModel("page.help.link", "");
+        add(helpLink)
         {
             private static final long serialVersionUID = -2510064191732926764L;
 


### PR DESCRIPTION
What is the code smell/issue?
Assignments should not be made from within sub-expressions
How is this code smell/issue relevant?
Assignments within sub-expressions are hard to spot and therefore make the code less readable.
How is this issue resolved?
We have removed assignment out of this expression and have used the add function after the assignment operation
