### PR TITLE
Replaced '@RequestMapping(method = RequestMethod.POST)' with '@PostMa…

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -359,9 +359,9 @@ public class AeroRemoteApiController
     }
 
     @ApiOperation(value = "Import a previously exported project")
-    @RequestMapping(//
+    @PostMapping(//
             value = ("/" + PROJECTS + "/" + IMPORT), //
-            method = RequestMethod.POST, //
+            
             consumes = MULTIPART_FORM_DATA_VALUE, //
             produces = APPLICATION_JSON_UTF8_VALUE)
     public ResponseEntity<RResponse<RProject>> projectImport(


### PR DESCRIPTION
Code smell:
Composed "@RequestMapping" variants should be preferred.
Explanation:
Variants of the @RequestMapping annotation to better represent the semantics of the annotated methods. The use of @GetMapping, @PostMapping, @PutMapping, @PatchMapping, and @DeleteMapping should be preferred to the use of the raw @RequestMapping(method = RequestMethod.XYZ).
Solution:
To solve the above code smell I replaced '@RequestMapping(method = RequestMethod.POST)' with '@PostMapping' for the representation of the semantics of the annotated methods.