### PR TITLE
Replacing switch statement with if-else 

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
@@ -118,14 +118,13 @@ public abstract class ApplicationPageBase
 
         // Override locale to be used by application
         String locale = settings.getProperty(SettingsUtil.CFG_LOCALE, "en");
-        switch (locale) {
-        case "auto":
+        if(locale == auto) {
             // Do nothing - locale is picked up from browser
-            break;
-        default:
+          }
+          else {
             // Override the locale in the session
             getSession().setLocale(Locale.forLanguageTag(locale));
-            break;
+            
         }
 
         // Add menubar


### PR DESCRIPTION
What is the issue?
switch statement is used for only one case 
How is the issue relevant ?
switch statements are generally used if there are more than 2 cases and they have less readability than other statements like if-else
How can we resolve this issue?
instead of using switch statement we can use if-else because there is only one case.

