### PR TITLE
Constructors of an "abstract" class should not be declared "public"

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/settings/ProjectSettingsPanelBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/settings/ProjectSettingsPanelBase.java
@@ -27,7 +27,7 @@ public abstract class ProjectSettingsPanelBase
 {
     private static final long serialVersionUID = -6844742938608503193L;
 
-    public ProjectSettingsPanelBase(String id)
+    protected ProjectSettingsPanelBase(String id)
     {
         super(id);
     }


### PR DESCRIPTION
What is the code smell/issue?
Constructors of an "abstract" class should not be declared "public"
Why is this code smell relevant?
Abstract classes should not have public constructors. Constructors of abstract classes can only be called in constructors of their subclasses. So there is no point in making them public
How is this issue resolved?
Changing the modifier from public to protected can resolve this issue.