### PR TITLE
Removing unnecessary curly braces

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
@@ -198,9 +198,9 @@ public abstract class ApplicationPageBase
             items.add(aComponent);
         }
 
-        RequestCycle.get().find(IPartialPageRequestHandler.class).ifPresent(handler -> {
+        RequestCycle.get().find(IPartialPageRequestHandler.class).ifPresent(handler -> 
             handler.add(footer);
-        });
+        );
     }
 
     public void removeFromFooter(Component aComponent)
@@ -209,8 +209,8 @@ public abstract class ApplicationPageBase
 
         items.remove(aComponent);
 
-        RequestCycle.get().find(IPartialPageRequestHandler.class).ifPresent(handler -> {
+        RequestCycle.get().find(IPartialPageRequestHandler.class).ifPresent(handler -> 
             handler.add(footer);
-        });
+        );
     }
 }


### PR DESCRIPTION
What is the issue?
There is no need of using curly braces

How is the issue relevent?
Curly bases are used only when there are multiple statements. As there is only one statement there is no need of using curly braces. It decreases the readability of the code.

How can we resolve this issue?
Remove the curly braces when there is only one statement.