### PR TITLE
Replaced '@RequestMapping(method = RequestMethod.GET)' with '@GetMapp…

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -401,8 +401,8 @@ public class AeroRemoteApiController
     }
 
     @ApiOperation(value = "Export a project to a ZIP file")
-    @RequestMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/"
-            + EXPORT), method = RequestMethod.GET, produces = { "application/zip",
+    @GetMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/"
+            + EXPORT),  produces = { "application/zip",
                     APPLICATION_JSON_UTF8_VALUE })
     public ResponseEntity<InputStreamResource> projectExport(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,


### PR DESCRIPTION
code smell:
Composed "@RequestMapping" variants should be preferred.
Explanation:
Variants of the @RequestMapping annotation to better represent the semantics of the annotated methods. The use of @GetMapping, @PostMapping, @PutMapping, @PatchMapping, and @DeleteMapping should be preferred to the use of the raw @RequestMapping(method = RequestMethod.XYZ).
Solution:
To solve the above code smell I replaced '@RequestMapping(method = RequestMethod.GET)' with '@GetMapping' for the representation of the semantics of the annotated methods.
