### PR TITLE
equality operators should not be used for terminating conditions in l…

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -628,7 +628,7 @@ var AnnotatorUI = (function($, window, undefined) {
                 // TODO put this in loops above, for efficiency the array slicing could be done separate still in single call
                 var trunc = false;
                 if (ss < selRect.length) {
-                  for (var s2 = 0; s2 != ss; s2++) {
+                  for (var s2 = 0; s2 <ss; s2++) {
                     selRect[s2].parentNode.removeChild(selRect[s2]);
                     es--;
                     trunc = true;


### PR DESCRIPTION
Code smell: Replacing the bounding condition in the for loop with a "less than" operator.
Explanation:

"!=" is the boundary condition used in the code above. This is used to define the loop's boundaries. The loop is terminated whenever the value of variable 's' is incremented to the size of'selRect'. Usage of the "not equals" operator is also a good option, but when all the conditions are taken into account, the value of 's' may become bigger than the size of 'selRect'. In such circumstances, the loop will never end and will continue to run indefinitely. Setting the boundary conditions with a comparison operator such as "less than" is always a smart choice.
Proposed Solution:
I'm going to apply a "less than" comparison operator to fix the above code smell. From 0 to less than the size of "selRect," the loop continues. The loop exits in the original code if "s==selRect.length," which suggests that the value of s should never be equal to the size of "selRect." As a result, the "less than ()" comparison operator is preferable than the "not equal to" operator.