### PR TITLE
Boxed boolean #2

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserSelectionPanel.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserSelectionPanel.java
@@ -73,7 +73,7 @@ class UserSelectionPanel
 
     private List<User> listUsers()
     {
-        if (showDisabled.getModelObject()) {
+        if (Boolean.TRUE.equals(showDisabled.getModelObject())) {
             return userRepository.listDisabledUsers();
         }
         else {


### PR DESCRIPTION
What is the code issue/smell, and is it relevant?
Boxed Boolean should be avoided in boolean expressions because it throws a null pointer exception if the value is invalid, and autoboxing will be applied directly by java & therefore, it increases complexity.
How to resolve it?
By implementing primitive boolean expressions, it is safer to avoid such conversion altogether and handle the null value explicitly.