### PR TITLE
Methods should not return constants

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -301,10 +301,7 @@ public abstract class WicketApplicationBase
         }
     }
 
-    protected String getLogoLocation()
-    {
-        return "/de/tudarmstadt/ukp/clarin/webanno/ui/core/logo/logo.png";
-    }
+    protected String getLogoLocation = "/de/tudarmstadt/ukp/clarin/webanno/ui/core/logo/logo.png";
 
     protected void initDefaultPageMounts()
     {


### PR DESCRIPTION
What is the code smell/issue?
Methods should not return constants

Why is this code smell relevant?
There’s no point in forcing the overhead of a method call for a method that always returns the same constant value. Even worse, the fact that a method call must be made will likely mislead developers who call the method thinking that something more is done. 
This rule raises an issue if on methods that contain only one statement: the return of a constant value. This increases the complexity of the code and also can cause readability issues.

How can we resolve this issue?
declaring a constant instead of a method which returns a constant value can resolve this issue which in turn decreases the complexity of the code.