### PR TITLE
removed 'APPLICATION_JSON_UTF8_VALUE' as it is deprecated.

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -451,7 +451,7 @@ public class AeroRemoteApiController
 
     @ApiOperation(value = "List documents in a project")
     @RequestMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/"
-            + DOCUMENTS, method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
+            + DOCUMENTS, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<List<RDocument>>> documentList(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId)
         throws Exception


### PR DESCRIPTION
code smell:
"@deprecated" code should not be used.
Explanation:
Once deprecated, classes, and interfaces, and their members should be avoided, rather than used, inherited, or extended. Deprecation is a warning that the class or interface has been superseded, and will eventually be removed. The deprecation period allows you to make a smooth transition away from the aging, soon-to-be-retired technology.
Solution:
To solve the above code smell I removed "APPLICATION_JSON_UTF8_VALUE" as it is deprecated and replaced it with "APPLICATION_JSON_VALUE".