### PR TITLE
Bug: Keyword should not be used as variable. Unwanted variable

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -22,7 +22,7 @@
  */
 // -*- Mode: JavaScript; tab-width: 2; indent-tabs-mode: nil; -*-
 // vim:set ft=javascript ts=2 sw=2 sts=2 cindent:
-var AnnotatorUI = (function($, window, undefined) {
+var AnnotatorUI = (function($, window) {
     var AnnotatorUI = function(dispatcher, svg) {
       var that = this;
       var arcDragOrigin = null;


### PR DESCRIPTION
Bug: Keywords should not be assigned.
Explanation: 
Keywords are reserved words that are not meant to be used. Hence these reserved variables should not be assigned. When these words are assigned the original definitions of them are changed. These definitions are not meant to be disturbed.
Possible solution: 
This assigning is not used anywhere, it is possible to remove the word "undefined".