### PR TITLE
    private static final String PROP_NAME = "name";     private stati…

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -143,11 +143,8 @@ public class AeroRemoteApiController
 
     private static final String VAL_ORIGINAL = "ORIGINAL";
 
-    private static final String PROP_ID = "id";
-    private static final String PROP_NAME = "name";
-    private static final String PROP_STATE = "state";
-    private static final String PROP_USER = "user";
-    private static final String PROP_TIMESTAMP = "user";
+    
+
 
     private static final String FORMAT_DEFAULT = "text";
 


### PR DESCRIPTION
…c final String PROP_STATE = "state";     private static final String PROP_USER = "user";     private static final String PROP_TIMESTAMP = "user";

If a private field is declared but not used in the program, it can be considered dead code and should therefore be removed. This will improve maintainability because developers will not wonder what the variable is used for.

**What's in the PR**
* ...

**How to test manually**
* ...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
