### PR TITLE
Equals operators should not be used in loops for terminating conditions

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -636,7 +636,7 @@ var AnnotatorUI = (function($, window, undefined) {
                   selRect = selRect.slice(ss);
                 }
                 if (es > -1) {
-                  for (var s2 = selRect.length - 1; s2 != es; s2--) {
+                  for (var s2 = selRect.length - 1; s2 > es; s2--) {
                     selRect[s2].parentNode.removeChild(selRect[s2]);
                     trunc = true;
                   }


### PR DESCRIPTION
Replacing the boundary condition in the for loop with a "greaterthan" operator.
Explanation:
The boundary condition in the code above is "!=". This is where the loop's bounds are defined. When the value of variable 's' is incremented to the size of 'selRect,' the loop ends. The "not equals" operator can also be used, however when all of the requirements are considered, the value of 's' may grow larger than the size of'selRect'. The loop will never close and will continue to operate endlessly in such conditions. It's always a good idea to use a comparison operator like "greater than" to set the border constraints.

Solution Suggestion:

To fix the following code smell, I'll use the "greater than" comparison operator. The loop continues from 0 to less than the size of "selRect." If "s==selRect.length," the loop terminates in the original code, implying that the value of s should never be equal to the size of "selRect." As a result, the comparison operator "greater than ()" is superior than the "not equal to" operator.