### PR TITLE
'PASSWORD' detected in this expression, review this potentially hard-coded credential.

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -70,7 +70,7 @@ public class LoginPage
     private static final long serialVersionUID = -333578034707672294L;
 
     private static final String ADMIN_DEFAULT_USERNAME = "admin";
-    private static final String ADMIN_DEFAULT_PASSWORD = "admin";
+    private static final String ADMIN_DEFAULT_PASSWORDHASH = "admin";
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -102,7 +102,7 @@ public class LoginPage
         if (userRepository.list().isEmpty()) {
             User admin = new User();
             admin.setUsername(ADMIN_DEFAULT_USERNAME);
-            admin.setPassword(ADMIN_DEFAULT_PASSWORD);
+            admin.setPassword(ADMIN_DEFAULT_PASSWORDHASH);
             admin.setEnabled(true);
             admin.setRoles(EnumSet.of(Role.ROLE_ADMIN, Role.ROLE_USER));
             userRepository.create(admin);
@@ -158,7 +158,7 @@ public class LoginPage
     {
         private static final long serialVersionUID = 1L;
         private String username;
-        private String password;
+        private String passwordhash;
         private String urlfragment;
 
         public LoginForm(String id)


### PR DESCRIPTION
What is code smell/issue?
'PASSWORD' detected in this expression, review this potentially hard-coded credential.
Why is this relevant?
it is easy to extract strings from an application source code or binary, credentials should not be hard-coded. This is particularly true for applications that are distributed or that are open-source.
Credentials should be stored outside of the code in a configuration file, a database, or a management service for secrets.
This rule flags instances of hard-coded credentials used in database and LDAP connections. It looks for hard-coded credentials in connection strings, and for variable names that match any of the patterns from the provided list.
It’s recommended to customize the configuration of this rule with additional credential words such as "oauthToken", "secret"
How can we resolve this issue?
encrypt the password with a hash function that can't be reversed. When the user types in a password, hash it and compare it to the hash that's stored in your application code. (Replace the password variable with a passwordHash variable.) Because the hash can't be (easily) decrypted, it's more secure than storing the plain-text password in your application source (or database, or wherever else you may be storing hashed passwords).