### PR TITLE
Weak SSL/TLS protocol is replaced with strong protocol

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
 import javax.persistence.NoResultException;
-
+import javax.net.ssl.SSLContext
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;

--- a/webanno-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImpl.java
+++ b/webanno-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImpl.java
@@ -135,7 +135,7 @@ public class MatomoTelemetrySupportImpl
         scheduler.scheduleAtFixedRate(() -> sendAlive(), 24, 24, TimeUnit.HOURS);
 
         try {
-            SSLContext trustAllSslContext = SSLContext.getInstance("SSL");
+            SSLContext trustAllSslContext = SSLContext.getInstance("TLSv1.2");
             trustAllSslContext.init(null, trustAllCerts, new java.security.SecureRandom());
 
             OkHttpClient client = new OkHttpClient.Builder()


### PR DESCRIPTION
Vulnerability:
Weak SSL/TLS protocols should not be used.
Explanation:
Using the weak SSL/TLS protocols may lead to risks on man-in-the-middle-attacks and issues like insecurity.
Solution:
To solve the above vulnerability I have replaced the SSL protocol with "TLSv1.1" which is a stronger protocol than the before one.