### PR TITLE
Initializing a temporary file in the user system with un-predictable …

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -376,7 +376,7 @@ public class AeroRemoteApiController
                 userRepository.isAdministrator(user));
 
         Project importedProject;
-        File tempFile = File.createTempFile("webanno-training", null);
+        File tempFile = File.createTempFile("unpredicatble-random-webanno-training", null);
         try (InputStream is = new BufferedInputStream(aFile.getInputStream());
                 OutputStream os = new FileOutputStream(tempFile);) {
             if (!ZipUtils.isZipStream(is)) {


### PR DESCRIPTION
Security Hotspot: 
Creating a temporary file in the user system with a predictable name.
Explanation: 
The temporary folders are generally created in the System. If the files saved by the application have predictable names, then an attacker may try to inject the virus into the system by creating a similar file before the application does. Moreover, these folders are not protected, it will be a very flexible attack for a hacker to launch.
Solution: 
The file names should be random and complex for an attacker to predict easily.