### PR TITLE
Initializing a temporary file in the user system with an un-predictab…

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -936,7 +936,7 @@ public class AeroRemoteApiController
         File tmpFile = null;
         CAS annotationCas;
         try {
-            tmpFile = File.createTempFile("upload", ".bin");
+            tmpFile = File.createTempFile("upload-random", ".unpredict-bin");
             aFile.transferTo(tmpFile);
             annotationCas = importExportService.importCasFromFile(tmpFile, project, format);
         }


### PR DESCRIPTION
Security Hotspot: 
Creating a temporary file in the user system with a predictable name.
Explanation: 
The temporary folders are generally created in the System. If the files saved by the application have predictable names, then an attacker may try to inject the virus into the system by creating a similar file before the application does. Moreover, these folders are not protected, it will be a very flexible attack for a hacker to launch.
Solution:
The file names should be random and complex for an attacker to predict easily.