### PR TITLE
Java modifiers are declared the incorrect order.

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
@@ -54,7 +54,7 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.core.footer.FooterItemRegistry;
 public abstract class ApplicationPageBase
     extends WebPage
 {
-    private final static Logger LOG = LoggerFactory.getLogger(ApplicationPageBase.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ApplicationPageBase.class);
 
     private static final long serialVersionUID = -1690130604031181803L;
 


### PR DESCRIPTION
What is the issue/code smell?
Java modifiers are declared the incorrect order.
Why is this issue/ code smell relevant?
This causes a minor impact as doesn't cause any technical problems but as most of the developers follow the standard order which says "static" should be before "final" that can reduce the readability of the code.
How is the issue resolved?
Reordering the modifiers to comply with the Java Language Specification i.e., changing the order from "public final static" to
" public static final"
