### PR TITLE
Class variable fields should not be specified by public access

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
@@ -78,7 +78,7 @@ public class ManageUsersPage
         private PasswordTextField passwordField;
         private PasswordTextField repeatPasswordField;
 
-        public transient String password;
+        private transient String password;
 
         @SuppressWarnings("unused")
         public transient String repeatPassword;


### PR DESCRIPTION
What is the code smell/issue and how it is relevant?
Public class variables do not satisfy all the rules of the encapsulation principle because of the following reasons:
1. Validation and authentication cannot be added.
2. The internal representation is exposed and cannot be changed afterward.
How to resolve it?
By providing private accessibility and accessor methods to the class variable field, prevents unauthorized modifications.
