### PR TITLE
Generic Exceptions should never thrown

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
@@ -138,7 +138,7 @@ public abstract class ApplicationPageBase
         }
         catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException
                 | InstantiationException e1) {
-            throw new RuntimeException(e1);
+            throw new MyOwnRuntimeException(e1);
         }
 
         feedbackPanel = new BootstrapFeedbackPanel("feedbackPanel");


### PR DESCRIPTION
What is the issue?
Generic Exceptions should never thrown

How is the issue relevant?
Using such generic exceptions as Error, RuntimeException, Throwable, and Exception prevents calling methods from handling true, system-generated exceptions differently than application-generated errors.

How can we resolve this issue?
Instead of using the generic exceptions, Throwing a dedicated exception is preferable and can resolve this issue.