### PR TITLE
Private methods should be placed in those classes which are required or called to use

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
@@ -117,6 +117,14 @@ public class ManageUsersPage
             add(new LambdaAjaxButton<>("save", ManageUsersPage.this::actionSave));
 
             add(new LambdaAjaxLink("cancel", ManageUsersPage.this::actionCancel));
+            private List<Role> getRoles()
+            {
+                  List<Role> roles = new ArrayList<>(Arrays.asList(Role.values()));
+                  if (remoteApiProperties != null && !remoteApiProperties.isEnabled()) {
+                                    roles.remove(Role.ROLE_REMOTE);
+                           }
+                  return roles;
+             }
         }
 
         private void validateUsername(IValidatable<String> aValidatable)
@@ -293,12 +301,4 @@ public class ManageUsersPage
         return userRepository.isAdministrator(userRepository.getCurrentUser());
     }
 
-    private List<Role> getRoles()
-    {
-        List<Role> roles = new ArrayList<>(Arrays.asList(Role.values()));
-        if (remoteApiProperties != null && !remoteApiProperties.isEnabled()) {
-            roles.remove(Role.ROLE_REMOTE);
-        }
-        return roles;
-    }
 }


### PR DESCRIPTION
What is the code issue/smell and how it is relevant?
Nested inner class cannot be able to access the private methods which are outside of it. Therefore it should move it into that class.
How to resolve it?
Moving the private method into the inner class which is able to access it. 
